### PR TITLE
Fix typo in profile page

### DIFF
--- a/src/pages/profile/Profile.res
+++ b/src/pages/profile/Profile.res
@@ -58,7 +58,7 @@ let default = () => {
           color=[xs(#primary300)]
           lineHeight=[xs(2.8->#rem)]
           fontWeight=[xs(#400)]>
-          {"Frontend performance enthusiast and Fine-Grained Reactivity super fan. Author of the SolidJS UI library and MarkoJS Core Team Memberr"->s}
+          {"Frontend performance enthusiast and Fine-Grained Reactivity super fan. Author of the SolidJS UI library and MarkoJS Core Team Member"->s}
         </Typography>
       </Stack>
       <Stack gap=[xs(#one(8.0))] mt=[xs(14.0)] alignItems=[xs(#center)]>


### PR DESCRIPTION
## Summary
- correct a typo in the profile page description

## Testing
- `yarn res:build`

------
https://chatgpt.com/codex/tasks/task_e_685ad39c5e2883328339296e8e45e987